### PR TITLE
Refactoring method checkPHPVersion

### DIFF
--- a/classes/util/global.func.php
+++ b/classes/util/global.func.php
@@ -11,11 +11,11 @@ function checkPHPVersion($minimumVersion)
     if ($phpVersionParts[0] < $minVersionParts[0])
       $check = false;
 
-  if ($minVersionPartsCount >= 2)
+  if ($minVersionPartsCount >= 2 && $phpVersionParts[0] == $minVersionParts[0])
     if ($phpVersionParts[1] < $minVersionParts[1])
       $check = false;
 
-  if ($minVersionPartsCount >= 3)
+  if ($minVersionPartsCount >= 3 && $phpVersionParts[0] == $minVersionParts[0] && $phpVersionParts[1] == $minVersionParts[1])
     if ($phpVersionParts[2] < $minVersionParts[2])
       $check = false;
 


### PR DESCRIPTION
I was installing iF.SVNAdmin on a Ubuntu 16.04 with PHP 7.0.4-7ubuntu2.1 and the method checkPHPVersion() was telling me that I needed PHP version bigger than 5.3. It was because the method keeps checking minor versions number even if the major one was asserted as valid.
So I fixed the method to accept the 7.0.4 version, which is bigger than 5.3.