### PR TITLE
add missing functions to LdapUserViewProvider

### DIFF
--- a/classes/providers/ldap/LdapUserViewProvider.class.php
+++ b/classes/providers/ldap/LdapUserViewProvider.class.php
@@ -357,6 +357,33 @@ class LdapUserViewProvider extends \IF_AbstractLdapConnector
 
 	/**
 	 * (non-PHPdoc)
+	 * @see svnadmin\core\interfaces.IGroupViewProvider::getGroupsOfSubgroup()
+	 */
+	public function getGroupsOfSubgroup($objGroup)
+	{
+		throw new Exception('not implemented');
+	}
+
+	/**
+	 * (non-PHPdoc)
+	 * @see svnadmin\core\interfaces.IGroupViewProvider::getSubgroupsOfGroup()
+	 */
+	public function getSubgroupsOfGroup($objGroup)
+	{
+		throw new Exception('not implemented');
+	}
+
+	/**
+	* (non-PHPdoc)
+	* @see svnadmin\core\interfaces.IGroupViewProvider::getSubgroupsOfGroup()
+	*/
+	public function isSubgroupInGroup($objSubgroup, $objGroup)
+	{
+		throw new Exception('not implemented');
+	}
+
+	/**
+	 * (non-PHPdoc)
 	 * @see svnadmin\core\interfaces.IGroupViewProvider::getGroups()
 	 */
 	public function getGroups()


### PR DESCRIPTION
LDAP does not work out of the box for me, i had to add the following three dummy functions to get it working:

- getGroupsOfSubgroup($objGroup)
- getSubgroupsOfGroup($objGroup)
- isSubgroupInGroup($objSubgroup, $objGroup)

Error message:

[Tue Aug 29 05:32:21.674119 2017] [:error] [pid 25831] [client 77.20.128.83:7317] PHP Fatal error:  Class svnadmin\\providers\\ldap\\LdapUserViewProvider contains 3 abstract methods and must therefore be declared abstract or implement the remaining methods (svnadmin\\core\\interfaces\\IGroupViewProvider::getGroupsOfSubgroup, svnadmin\\core\\interfaces\\IGroupViewProvider::getSubgroupsOfGroup, svnadmin\\core\\interfaces\\IGroupViewProvider::isSubgroupInGroup) in /srv/www/htdocs/svnadmin/classes/providers/ldap/LdapUserViewProvider.class.php on line 22
