### PR TITLE
support proxied authentication for REMOTE_USER and X-Forwarded-User

### DIFF
--- a/classes/core/Engine.class.php
+++ b/classes/core/Engine.class.php
@@ -336,6 +336,18 @@ class Engine
 			return true;
 		}
 
+    // use proxied configuration if available
+		if (isset($_SERVER["X-Forwarded-User"]))
+		{
+			$_SESSION["svnadmin_username"] = $_SERVER["X-Forwarded-User"];
+		}
+
+    // use proxied configuration if available
+		if (isset($_SERVER["REMOTE_USER"]))
+		{
+			$_SESSION["svnadmin_username"] = $_SERVER["REMOTE_USER"];
+		}
+
 		// At this place the authentication is ON.
 		if (!isset($_SESSION["svnadmin_username"]) || empty($_SESSION["svnadmin_username"]))
 		{


### PR DESCRIPTION
We use Basic Apache Authentication for our web services. This patch adds support for proxied authentication via REMOTE_USER and X-Forwarded-User.

To use it something like this is necessary in the apache vhost configuration:

```
  <Proxy *>
    Options FollowSymLinks MultiViews
    RequestHeader set X-Forwarded-User %{REMOTE_USER}s
    RequestHeader set REMOTE_USER %{REMOTE_USER}s
  </Proxy>
```